### PR TITLE
[FIX] sale_line_mrp_link: create only if there is no manufacturing order already created

### DIFF
--- a/sale_line_mrp_link/__init__.py
+++ b/sale_line_mrp_link/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Esther Martín - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from . import models

--- a/sale_line_mrp_link/__manifest__.py
+++ b/sale_line_mrp_link/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015 Esther Martín - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
@@ -9,12 +8,11 @@
     "license": "AGPL-3",
     "author": "AvanzOSC",
     "website": "http://www.avanzosc.es",
-    "contributors": [
-        "Esther Martín <esthermartin@avanzosc.es>",
-        "Ana Juaristi <anajuaristi@avanzosc.es>",
-    ],
     "depends": [
-        "sale", "sale_stock", "mrp_scheduled_products",
+        "sale",
+        "sale_stock",
+        "mrp",
+        "mrp_scheduled_products",
     ],
     "data": [
         "views/sale_view.xml",

--- a/sale_line_mrp_link/i18n/sale_line_mrp_link.pot
+++ b/sale_line_mrp_link/i18n/sale_line_mrp_link.pot
@@ -18,7 +18,7 @@ msgstr ""
 #. module: sale_line_mrp_link
 #: model_terms:ir.ui.view,arch_db:sale_line_mrp_link.sale_order_production_view_form
 msgid "Create MO"
-msgstr "Crear OF"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.actions.server,name:sale_line_mrp_link.create_mrp_scheduled_lines
@@ -28,17 +28,17 @@ msgstr ""
 #. module: sale_line_mrp_link
 #: model:ir.model.fields,field_description:sale_line_mrp_link.field_mrp_production__partner_id
 msgid "Customer"
-msgstr "Cliente"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.model.fields,field_description:sale_line_mrp_link.field_sale_order_line__manufacturable_product
 msgid "Manufacturable Product"
-msgstr "Producto fabricable"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model_terms:ir.ui.view,arch_db:sale_line_mrp_link.sale_order_production_view_form
 msgid "Manufacturing Orders"
-msgstr "Órdenes de producción"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: code:addons/sale_line_mrp_link/models/sale.py:52
@@ -49,63 +49,63 @@ msgstr ""
 #. module: sale_line_mrp_link
 #: model:ir.model.fields,field_description:sale_line_mrp_link.field_sale_order_line__product_line_ids
 msgid "Product line"
-msgstr "Línea de productos"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.model.fields,field_description:sale_line_mrp_link.field_sale_order_line__mrp_production_id
 msgid "Production"
-msgstr "Producción"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.model,name:sale_line_mrp_link.model_mrp_production
 msgid "Production Order"
-msgstr "Orden de producción"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.model,name:sale_line_mrp_link.model_mrp_production_product_line
 msgid "Production Scheduled Product"
-msgstr "Fabricación planificada producto"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.model.fields,field_description:sale_line_mrp_link.field_mrp_production__sale_line_id
 msgid "Sale Line"
-msgstr "Línea de venta"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.model,name:sale_line_mrp_link.model_sale_order
 #: model:ir.model.fields,field_description:sale_line_mrp_link.field_mrp_production__sale_order_id
 msgid "Sale Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.model.fields,field_description:sale_line_mrp_link.field_mrp_production_product_line__sale_line_id
 msgid "Sale lines"
-msgstr "Líneas de venta"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.model,name:sale_line_mrp_link.model_sale_order_line
 msgid "Sales Order Line"
-msgstr "Línea de pedido de venta"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model_terms:ir.ui.view,arch_db:sale_line_mrp_link.sale_order_production_view_form
 msgid "Scheduled Products"
-msgstr "Productos planificados"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.model,name:sale_line_mrp_link.model_stock_rule
 msgid "Stock Rule"
-msgstr "Regla de Inventario"
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: code:addons/sale_line_mrp_link/models/sale.py:60
 #: code:addons/sale_line_mrp_link/models/sale.py:66
 #, python-format
 msgid "The quantity must be positive."
-msgstr "La cantidad debe ser positiva."
+msgstr ""
 
 #. module: sale_line_mrp_link
 #: model:ir.model.fields,help:sale_line_mrp_link.field_mrp_production__partner_id
 msgid "You can find a customer by its Name, TIN, Email or Internal Reference."
-msgstr "Puedes encontrar un cliente por su nombre, CIF, email o referencia interna"
+msgstr ""
 

--- a/sale_line_mrp_link/models/stock_rule.py
+++ b/sale_line_mrp_link/models/stock_rule.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Mikel Arregi Etxaniz - AvanzOSC
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-from odoo import models
+from odoo import api, models
 
 
 class StockRule(models.Model):
@@ -8,10 +8,50 @@ class StockRule(models.Model):
 
     def _prepare_mo_vals(self, product_id, product_qty, product_uom,
                          location_id, name, origin, values, bom):
-        res = super()._prepare_mo_vals(product_id, product_qty, product_uom,
-                                       location_id, name, origin, values, bom)
-        extra_fields = self.env.context.get('sale_line_fields')
-        if extra_fields:
-            res['sale_line_id'] = extra_fields.get('sale_line_id')
-            res['active'] = extra_fields.get('active')
+        res = super()._prepare_mo_vals(
+            product_id, product_qty, product_uom, location_id, name, origin,
+            values, bom)
+        context = self.env.context
+        if 'sale_line_id' in context:
+            res['sale_line_id'] = context.get('sale_line_id')
+        if 'active' in self.env.context:
+            res['active'] = context.get('active')
         return res
+
+    @api.multi
+    def _run_manufacture(
+            self, product_id, product_qty, product_uom, location_id, name,
+            origin, values):
+        if not self.env.context.get("production_id", False):
+            super(StockRule, self)._run_manufacture(
+                product_id, product_qty, product_uom, location_id, name,
+                origin, values)
+        else:
+            Production = self.env['mrp.production']
+            ProductionSudo = Production.sudo().with_context(
+                force_company=values['company_id'].id)
+            production = ProductionSudo.browse(
+                self.env.context.get("production_id"))
+            production.write({
+                "move_dest_ids": (values.get('move_dest_ids') and
+                                  [(4, x.id) for x in values['move_dest_ids']]
+                                  or False),
+                "propagate": self.propagate,
+            })
+            origin_production = (
+                values.get('move_dest_ids') and
+                values['move_dest_ids'][0].raw_material_production_id or False)
+            orderpoint = values.get('orderpoint_id')
+            if orderpoint:
+                production.message_post_with_view(
+                    'mail.message_origin_link',
+                    values={'self': production,
+                            'origin': orderpoint},
+                    subtype_id=self.env.ref('mail.mt_note').id)
+            if origin_production:
+                production.message_post_with_view(
+                    'mail.message_origin_link',
+                    values={'self': production,
+                            'origin': origin_production},
+                    subtype_id=self.env.ref('mail.mt_note').id)
+        return True

--- a/sale_line_mrp_link/views/sale_view.xml
+++ b/sale_line_mrp_link/views/sale_view.xml
@@ -1,52 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openerp>
-    <data>
-<!--        <record model="ir.ui.view" id="sale.sale_order_buttons">-->
-<!--            <field name="name">sale.order.buttons</field>-->
-<!--            <field name="model">sale.order</field>-->
-<!--            <field name="inherit_id" ref="sale.view_order_form" />-->
-<!--            <field name="arch" type="xml">-->
-<!--                <div name="button_box">-->
-<!--                    <div class="oe_right oe_button_box" name="buttons">-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </field>-->
-<!--        </record>-->
-        <record id="sale_order_production_view_form" model="ir.ui.view">
-            <field name="name">sale.order.production.form</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form"/>
-            <field name="arch" type="xml">
-                <div name="button_box" position="inside">
-                    <button class="oe_stat_button" type="object" name="action_show_scheduled_products"
-                            icon="fa-pencil-square-o">
-                        <div>Scheduled products</div>
-                    </button>
-                    <button class="oe_stat_button" type="object" name="action_show_manufacturing_orders"
-                            icon="fa-pencil-square-o">
-                        <div>Manufacturing Orders</div>
-                    </button>
-                </div>
+<odoo>
+    <record id="sale_order_production_view_form" model="ir.ui.view">
+        <field name="name">sale.order.production.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button class="oe_stat_button" type="object" name="action_show_scheduled_products"
+                        icon="fa-pencil-square-o" string="Scheduled Products" />
+                <button class="oe_stat_button" type="object" name="action_show_manufacturing_orders"
+                        icon="fa-pencil-square-o" string="Manufacturing Orders" />
+            </div>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='price_tax']"
+                   position="after">
+                <field name="mrp_production_id" readonly="1"
+                       attrs="{'invisible':[('mrp_production_id', '=', False)]}" />
+                <field name="manufacturable_product" invisible="1"/>
+                <button name="action_create_mrp" string="Create MO"
+                        attrs="{'invisible':['|', ('mrp_production_id', '!=', False), ('manufacturable_product','=', False)]}"
+                        type="object" />
+            </xpath>
+        </field>
+    </record>
 
-                <xpath expr="//field[@name='order_line']/tree//field[@name='price_tax']"
-                       position="after">
-                    <field name="mrp_production_id" readonly="1"
-                           attrs="{'invisible':[('mrp_production_id', '=', False)]}" />
-                    <field name="manufacturable_product" invisible="1"/>
-                    <button name="action_create_mrp" string="Create MO"
-                            attrs="{'invisible':['|', ('mrp_production_id', '!=', False), ('manufacturable_product','=', False)]}"
-                            type="object" />
-                </xpath>
-            </field>
-        </record>
-
-            <record id="create_mrp_scheduled_lines" model="ir.actions.server">
-                    <field name="name">Create Scheduled Lines</field>
-                    <field name="model_id" ref="model_sale_order"/>
-                    <field name="binding_model_id" ref="model_sale_order"/>
-                    <field name="state">code</field>
-                    <field name="condition">True</field>
-                    <field name="code">if records: records.action_create_mrp_from_lines()</field>
-                </record>
-    </data>
-</openerp>
+    <record id="create_mrp_scheduled_lines" model="ir.actions.server">
+        <field name="name">Create Scheduled Lines</field>
+        <field name="model_id" ref="model_sale_order"/>
+        <field name="binding_model_id" ref="model_sale_order"/>
+        <field name="state">code</field>
+        <field name="code">if records: records.action_create_mrp_from_lines()</field>
+    </record>
+</odoo>


### PR DESCRIPTION
```
Name                                              Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
/sale_line_mrp_link/models/mrp_production.py          9      0   100%
/sale_line_mrp_link/models/sale.py                   63      3    95%   65, 82-83
/sale_line_mrp_link/models/stock_rule.py             25      2    92%   46, 52
---------------------------------------------------------------------------------
TOTAL                                                97      5    94%
```