### PR TITLE
[FIX] mrp_workorder_grouping_by_material: production_lot and material

### DIFF
--- a/mrp_workorder_grouping_by_material/models/mrp_workorder_nest.py
+++ b/mrp_workorder_grouping_by_material/models/mrp_workorder_nest.py
@@ -80,7 +80,7 @@ class MrpWorkorderNest(models.Model):
     @api.onchange('lot_id')
     def onchange_lot_id(self):
         for line in self.nested_line_ids:
-            line.finished_lot_id = self.lot_id
+            line.lot_id = self.lot_id
 
     @api.model
     def create(self, vals):
@@ -198,6 +198,7 @@ class MrpWorkorderNestLine(models.Model):
         digits=dp.get_precision('Product Unit of Measure'))
     finished_lot_id = fields.Many2one('stock.production.lot', 'Lot/Serial Number',
         domain="[('product_id', '=', product_id)]")
+    lot_id = fields.Many2one("")
     workorder_id = fields.Many2one(comodel_name="mrp.workorder")
     qty_produced = fields.Float(string="Produce Quantity",
                                 related="workorder_id.qty_produced")
@@ -241,9 +242,13 @@ class MrpWorkorderNestLine(models.Model):
                 res.update({
                     'qty_producing': line.qty_producing,
                 })
-            if line.finished_lot_id != line.related_finished_lot_id:
+            if line.finished_lot_id:
                 res.update({
                     'finished_lot_id': line.finished_lot_id.id,
                 })
+            if line.lot_id:
+                move_line = line.res_id.raw_workorder_line_ids.filtered(
+                    lambda x: x.product_id == line.nest_id.main_product_id)
+                move_line.lot_id = line.lot_id
             if res:
                 line.workorder_id.write(res)

--- a/mrp_workorder_grouping_by_material/views/mrp_workorder_nest_view.xml
+++ b/mrp_workorder_grouping_by_material/views/mrp_workorder_nest_view.xml
@@ -76,6 +76,7 @@
                                 <field name="qty_producing"/>
                                 <field name="company_id" invisible="1"/>
                                 <field name="finished_lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}"/>
+                                <field name="lot_id"/>
                                 <field name="qty_produced" readonly="1"/>
                                 <field name="qty_production" readonly="1"/>
                                 <field name="product_uom_id" readonly="1"/>


### PR DESCRIPTION
lot assignations in nest