### PR TITLE
[ADD] mrp_production_workorder_button: In MRP production, the button …

### DIFF
--- a/mrp_production_workorder_button/README.rst
+++ b/mrp_production_workorder_button/README.rst
@@ -1,0 +1,28 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===============================
+MRP Production Workorder Button
+===============================
+
+* In MRP production, the button that creates the work orders invisible until all the products are available and reserved.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/avanzosc/mrp-addons/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+* Berezi Amubieta <bereziamubieta@avanzosc.es>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>
+
+Do not contact contributors directly about support or help with technical issues.

--- a/mrp_production_workorder_button/__manifest__.py
+++ b/mrp_production_workorder_button/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Berezi Amubieta - AvanzOSC
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "MRP Production Workorder Button",
+    "version": "12.0.1.0.0",
+    "author": "AvanzOSC",
+    "license": "AGPL-3",
+    "category": "Manufacturing",
+    "website": "http://www.avanzosc.es",
+    "depends": [
+        "mrp",
+    ],
+    "data": [
+        "views/mrp_production_views.xml",
+    ],
+    "installable": True
+}

--- a/mrp_production_workorder_button/i18n/es.po
+++ b/mrp_production_workorder_button/i18n/es.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-12-03 09:44+0000\n"
+"PO-Revision-Date: 2021-12-03 09:44+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/mrp_production_workorder_button/i18n/mrp_production_workorder_button.pot
+++ b/mrp_production_workorder_button/i18n/mrp_production_workorder_button.pot
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-12-03 09:43+0000\n"
+"PO-Revision-Date: 2021-12-03 09:43+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/mrp_production_workorder_button/views/mrp_production_views.xml
+++ b/mrp_production_workorder_button/views/mrp_production_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="mrp_production_form_view" model="ir.ui.view">
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view" />
+        <field name="arch" type="xml">
+            <button name="button_plan" position="attributes">
+                <attribute name="attrs">{'invisible': [('availability', '!=', 'assigned')]}</attribute>
+            </button>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
…that creates the work orders invisible until all the products are available and reserved.