### PR TITLE
Update mrp_workorder_grouping_by_material/mrp_workorder.py

### DIFF
--- a/mrp_workorder_grouping_by_material/models/mrp_workorder.py
+++ b/mrp_workorder_grouping_by_material/models/mrp_workorder.py
@@ -55,6 +55,7 @@ class MrpWorkorder(models.Model):
     )
 
     @api.depends(
+        "nested_ids",
         "nested_line_ids",
         "nested_line_ids.nest_id",
     )
@@ -64,6 +65,7 @@ class MrpWorkorder(models.Model):
             order.nested_count = len(order.mapped("nested_line_ids.nest_id"))
 
     @api.depends(
+        "nested_ids",
         "nested_line_ids",
         "nested_line_ids.qty_producing",
         "qty_production",


### PR DESCRIPTION
Add "nested_ids" in api.depends, so calculations in workorder are updated if any change in nested_ids. (i.e. when deleting a nest, the following fields stayed not updated: nested_ids, nested_count, qty_nested, nested_status)