### PR TITLE
[16.0][FIX] quality_control_mrp_oca_ext: The "Inspection type" field …

### DIFF
--- a/quality_control_mrp_oca_ext/views/product_template_view.xml
+++ b/quality_control_mrp_oca_ext/views/product_template_view.xml
@@ -14,7 +14,7 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
-            <field name="type" position="after">
+            <field name="detailed_type" position="after">
                 <field name="qc_inspection_type_id" />
             </field>
         </field>


### PR DESCRIPTION
…was not visible in the "form" view of the product template.