### PR TITLE
[16.0][FIX] mrp_manual_sale_info: WO manual partner id related to the…

### DIFF
--- a/mrp_manual_sale_info/models/mrp_workorder.py
+++ b/mrp_manual_sale_info/models/mrp_workorder.py
@@ -16,7 +16,7 @@ class MrpWorkorder(models.Model):
     )
     manual_partner_id = fields.Many2one(
         comodel_name="res.partner",
-        related="manual_sale_id.partner_id",
+        related="production_id.manual_partner_id",
         string="Customer",
         readonly=True,
         store=True,


### PR DESCRIPTION
… manufacturing partner instead of the sale order partner.