### PR TITLE
[16.0][FIX] mrp_show_finished_moves: clear groups="base.group_no_one"…

### DIFF
--- a/mrp_show_finished_moves/views/stock_move_views.xml
+++ b/mrp_show_finished_moves/views/stock_move_views.xml
@@ -9,6 +9,7 @@
             </xpath>
             <xpath expr="//field[@name='date']" position="attributes">
                 <attribute name="optional">hide</attribute>
+                <attribute name="groups" />
             </xpath>
             <xpath expr="//field[@name='company_id']" position="attributes">
                 <attribute name="optional">hide</attribute>


### PR DESCRIPTION
… on date field, sort by it crashes for users without access